### PR TITLE
Add StrategyManager and UnitManager; finish cleanup of Tools.h/cpp

### DIFF
--- a/src/starterbot/AutoPilotBot.h
+++ b/src/starterbot/AutoPilotBot.h
@@ -1,47 +1,26 @@
 #pragma once
 
 #include "Tools.h"
+#include "StrategyManager.h"
 
 // Chooses the frame time in milliseconds that the game should be run at.
 constexpr int LOCAL_SPEED = 10;
 
-// This class is the primary class that governs the entire bot. It receives events about
-// when each game starts and ends, plus whatever actions happen during the game. The
-// primary job of this class is to give the various manager classes the information they
-// need to know to do their jobs.
-class AutoPilotBot {
-public:
-	// Called whenever a game starts with the number of the current game. The AutoPilotBot
-	// object is created once and reused for every match, so initialization for each game
-	// should happen here rather than in the constructor.
-	void onStart(int gameCount);
+class AutoPilotBot : public EventReceiver {
+private:
+	StrategyManager m_strategyManager;
 
-	// Called for every frame of the game. Much of the main bot logic occurs here.
-	void onFrame();
+protected:
+	virtual void notifyMembers(const bw::Event& event) override;
 
-	// Like onFrame(), this is called for every frame of the game. However, drawing code
-	// should be placed here rather than in onFrame().
-	void onDraw();
-
-	// Called whenever the game ends, plus information about whether the bot won or lost.
-	void onEnd(bool isWinner);
-
-	// Called whenever the user sends a chat message. This can be used to catch control
-	// messages to control bot functionality or enable debugging features.
-	void onSendText(const std::string& text);
-
-	void onUnitCreate(bw::Unit unit);
-	void onUnitDestroy(bw::Unit unit);
-	void onUnitComplete(bw::Unit unit);
-	void onUnitMorph(bw::Unit unit);
-	void onUnitRenegade(bw::Unit unit);
-	void onUnitEvade(bw::Unit unit);
-	void onUnitDiscover(bw::Unit unit);
-	void onUnitShow(bw::Unit unit);
-	void onUnitHide(bw::Unit unit);
+	virtual void onStart() override;
+	virtual void onDraw() override;
+	virtual void onEnd(bool isWinner) override;
 
 private:
-	void sendIdleWorkersToMinerals();
-	void trainAdditionalWorkers();
-	void buildAdditionalSupply();
+	void drawUnitBoxes();
+	void drawCommands();
+
+	void drawHealthBars();
+	void drawHealthBar(bw::Unit unit, double ratio, bw::Color color, int yOffset);
 };

--- a/src/starterbot/BuildingManager.cpp
+++ b/src/starterbot/BuildingManager.cpp
@@ -1,0 +1,32 @@
+#include "BuildingManager.h"
+
+BuildingManager::BuildingManager(UnitManager& unitManager) :
+    m_unitManager(unitManager) {
+}
+
+bool BuildingManager::addTrainRequest(bw::UnitType type) {
+    bw::Unit building = m_unitManager.reserveUnit(bw::Filter::GetType == type.whatBuilds().first);
+    if (building == nullptr) {
+        return false;
+    }
+
+    if (!building->train(type)) {
+        m_unitManager.releaseUnit(building);
+        return false;
+    }
+
+    m_buildings.insert(building);
+    return true;
+}
+
+void BuildingManager::onStart() {
+    m_buildings.clear();
+}
+
+void BuildingManager::onFrame() {
+    m_unitManager.releaseUnits(m_buildings, !bw::Filter::IsTraining);
+}
+
+void BuildingManager::onUnitDestroy(bw::Unit unit) {
+    m_buildings.erase(unit);
+}

--- a/src/starterbot/BuildingManager.h
+++ b/src/starterbot/BuildingManager.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Tools.h"
+#include "UnitManager.h"
+
+class BuildingManager : public EventReceiver {
+private:
+    UnitManager& m_unitManager;
+
+    bw::Unitset m_buildings;
+
+public:
+    BuildingManager(UnitManager& unitManager);
+
+    bool addTrainRequest(bw::UnitType type);
+
+protected:
+    virtual void onStart() override;
+    virtual void onFrame() override;
+    virtual void onUnitDestroy(bw::Unit unit) override;
+};

--- a/src/starterbot/StrategyManager.cpp
+++ b/src/starterbot/StrategyManager.cpp
@@ -1,7 +1,14 @@
 #include "StrategyManager.h"
 
-void StrategyManager::notifyMembers(const bw::Event &event) {
+StrategyManager::StrategyManager() :
+//    m_productionManager(m_unitManager),
+    m_buildingManager(m_unitManager) {
+}
+
+void StrategyManager::notifyMembers(const bw::Event& event) {
     m_unitManager.notifyReceiver(event);
+//    m_productionManager.notifyReceiver(event);
+    m_buildingManager.notifyReceiver(event);
 }
 
 void StrategyManager::onStart() {
@@ -15,5 +22,50 @@ void StrategyManager::onStart() {
 }
 
 void StrategyManager::onFrame() {
-    // TODO: We need ProductionManager and BuildingManager before this can be implemented.
+    if (m_strategyItem >= m_strategy.size()) {
+        return;
+    }
+
+    const ActionItem& item = m_strategy[m_strategyItem];
+
+    switch (item.type) {
+    case ActionType::BUILD: {
+#if 0
+        int current = m_unitManager.peekCount(bw::Filter::GetType == item.unit, false);
+        int progress = m_unitManager.peekCount(bw::Filter::GetType == item.unit, true) +
+            m_productionManager.countBuildRequests(item.unit);
+
+        if (current >= item.count) {
+            m_strategyItem++;
+        }
+
+        while (progress < item.count && m_productionManager.addBuildRequest(item.unit)) {
+            progress++;
+        }
+#endif
+        break;
+    }
+
+    case ActionType::TRAIN: {
+        int current = m_unitManager.peekCount(bw::Filter::GetType == item.unit, false);
+        int progress = m_unitManager.peekCount(bw::Filter::GetType == item.unit, true);
+
+        if (current >= item.count) {
+            m_strategyItem++;
+        }
+
+        while (progress < item.count && m_buildingManager.addTrainRequest(item.unit)) {
+            progress++;
+        }
+        break;
+    }
+
+    case ActionType::SCOUT:
+        // TODO
+        break;
+
+    case ActionType::ATTACK:
+        // TODO
+        break;
+    }
 }

--- a/src/starterbot/StrategyManager.cpp
+++ b/src/starterbot/StrategyManager.cpp
@@ -1,0 +1,19 @@
+#include "StrategyManager.h"
+
+void StrategyManager::notifyMembers(const bw::Event &event) {
+    m_unitManager.notifyReceiver(event);
+}
+
+void StrategyManager::onStart() {
+    m_strategy = {
+        {ActionType::TRAIN, bw::UnitTypes::Protoss_Probe, 8},
+        {ActionType::BUILD, bw::UnitTypes::Protoss_Pylon, 1},
+        {ActionType::TRAIN, bw::UnitTypes::Protoss_Probe, 15},
+        {ActionType::BUILD, bw::UnitTypes::Protoss_Pylon, 2},
+    };
+    m_strategyItem = 0;
+}
+
+void StrategyManager::onFrame() {
+    // TODO: We need ProductionManager and BuildingManager before this can be implemented.
+}

--- a/src/starterbot/StrategyManager.h
+++ b/src/starterbot/StrategyManager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Tools.h"
+#include "UnitManager.h"
+
+#include <vector>
+
+enum class ActionType {
+    BUILD,
+    TRAIN,
+    SCOUT,
+    ATTACK,
+};
+
+struct ActionItem {
+    ActionType type;
+    bw::UnitType unit;
+    int count;
+};
+
+class StrategyManager : public EventReceiver {
+private:
+    UnitManager m_unitManager;
+
+    std::vector<ActionItem> m_strategy;
+    int m_strategyItem;
+
+protected:
+    virtual void notifyMembers(const bw::Event& event) override;
+
+    virtual void onStart() override;
+    virtual void onFrame() override;
+};

--- a/src/starterbot/StrategyManager.h
+++ b/src/starterbot/StrategyManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "BuildingManager.h"
+//#include "ProductionManager.h"
 #include "Tools.h"
 #include "UnitManager.h"
 
@@ -22,8 +24,14 @@ class StrategyManager : public EventReceiver {
 private:
     UnitManager m_unitManager;
 
+//    ProductionManager m_productionManager;
+    BuildingManager m_buildingManager;
+
     std::vector<ActionItem> m_strategy;
     int m_strategyItem;
+
+public:
+    StrategyManager();
 
 protected:
     virtual void notifyMembers(const bw::Event& event) override;

--- a/src/starterbot/Tools.cpp
+++ b/src/starterbot/Tools.cpp
@@ -3,185 +3,54 @@
 bw::GameWrapper& g_game = bw::Broodwar;
 bw::Player g_self = nullptr;
 
-BWAPI::Unit Tools::GetClosestUnitTo(BWAPI::Position p, const BWAPI::Unitset& units) {
-    BWAPI::Unit closestUnit = nullptr;
+int g_gameCount = 0;
 
-    for (auto& u : units) {
-        if (!closestUnit || u->getDistance(p) < closestUnit->getDistance(p)) {
-            closestUnit = u;
-        }
-    }
+void EventReceiver::notifyReceiver(const bw::Event& event) {
+    notifyMembers(event);
 
-    return closestUnit;
-}
-
-BWAPI::Unit Tools::GetClosestUnitTo(BWAPI::Unit unit, const BWAPI::Unitset& units) {
-    if (!unit) { return nullptr; }
-    return GetClosestUnitTo(unit->getPosition(), units);
-}
-
-int Tools::CountUnitsOfType(BWAPI::UnitType type, const BWAPI::Unitset& units) {
-    int sum = 0;
-    for (auto& unit : units) {
-        if (unit->getType() == type) {
-            sum++;
-        }
-    }
-
-    return sum;
-}
-
-BWAPI::Unit Tools::GetUnitOfType(BWAPI::UnitType type) {
-    // For each unit that we own
-    for (auto& unit : BWAPI::Broodwar->self()->getUnits()) {
-        // if the unit is of the correct type, and it actually has been constructed, return it
-        if (unit->getType() == type && unit->isCompleted()) {
-            return unit;
-        }
-    }
-
-    // If we didn't find a valid unit to return, make sure we return nullptr
-    return nullptr;
-}
-
-// Attempt tp construct a building of a given type 
-bool Tools::BuildBuilding(BWAPI::UnitType type) {
-    // Get the type of unit that is required to build the desired building
-    BWAPI::UnitType builderType = type.whatBuilds().first;
-
-    // Get a unit that we own that is of the given type so it can build
-    // If we can't find a valid builder unit, then we have to cancel the building
-    BWAPI::Unit builder = Tools::GetUnitOfType(builderType);
-    if (!builder) { return false; }
-
-    // Get a location that we want to build the building next to
-    BWAPI::TilePosition desiredPos = BWAPI::Broodwar->self()->getStartLocation();
-
-    // Ask BWAPI for a building location near the desired position for the type
-    int maxBuildRange = 64;
-    bool buildingOnCreep = type.requiresCreep();
-    BWAPI::TilePosition buildPos = BWAPI::Broodwar->getBuildLocation(type, desiredPos, maxBuildRange, buildingOnCreep);
-    return builder->build(type, buildPos);
-}
-
-void Tools::DrawUnitCommands() {
-    for (auto& unit : BWAPI::Broodwar->self()->getUnits()) {
-        const BWAPI::UnitCommand& command = unit->getLastCommand();
-
-        // If the previous command had a ground position target, draw it in red
-        // Example: move to location on the map
-        if (command.getTargetPosition() != BWAPI::Positions::None) {
-            BWAPI::Broodwar->drawLineMap(unit->getPosition(), command.getTargetPosition(), BWAPI::Colors::Red);
-        }
-
-        // If the previous command had a tile position target, draw it in red
-        // Example: build at given tile position location
-        if (command.getTargetTilePosition() != BWAPI::TilePositions::None) {
-            BWAPI::Broodwar->drawLineMap(unit->getPosition(), BWAPI::Position(command.getTargetTilePosition()), BWAPI::Colors::Green);
-        }
-
-        // If the previous command had a unit target, draw it in red
-        // Example: attack unit, mine mineral, etc
-        if (command.getTarget() != nullptr) {
-            BWAPI::Broodwar->drawLineMap(unit->getPosition(), command.getTarget()->getPosition(), BWAPI::Colors::White);
-        }
-    }
-}
-
-void Tools::DrawUnitBoundingBoxes() {
-    for (auto& unit : BWAPI::Broodwar->getAllUnits()) {
-        BWAPI::Position topLeft(unit->getLeft(), unit->getTop());
-        BWAPI::Position bottomRight(unit->getRight(), unit->getBottom());
-        BWAPI::Broodwar->drawBoxMap(topLeft, bottomRight, BWAPI::Colors::White);
-    }
-}
-
-int Tools::GetTotalSupply(bool inProgress) {
-    // start the calculation by looking at our current completed supplyt
-    int totalSupply = BWAPI::Broodwar->self()->supplyTotal();
-
-    // if we don't want to calculate the supply in progress, just return that value
-    if (!inProgress) { return totalSupply; }
-
-    // if we do care about supply in progress, check all the currently constructing units if they will add supply
-    for (auto& unit : BWAPI::Broodwar->self()->getUnits()) {
-        // ignore units that are fully completed
-        if (unit->isCompleted()) { continue; }
-
-        // if they are not completed, then add their supply provided to the total supply
-        totalSupply += unit->getType().supplyProvided();
-    }
-
-    // one last tricky case: if a unit is currently on its way to build a supply provider, add it
-    for (auto& unit : BWAPI::Broodwar->self()->getUnits()) {
-        // get the last command given to the unit
-        const BWAPI::UnitCommand& command = unit->getLastCommand();
-
-        // if it's not a build command we can ignore it
-        if (command.getType() != BWAPI::UnitCommandTypes::Build) { continue; }
-
-        // add the supply amount of the unit that it's trying to build
-        totalSupply += command.getUnitType().supplyProvided();
-    }
-
-    return totalSupply;
-}
-
-void Tools::DrawUnitHealthBars() {
-    // how far up from the unit to draw the health bar
-    int verticalOffset = -10;
-
-    // draw a health bar for each unit on the map
-    for (auto& unit : BWAPI::Broodwar->getAllUnits()) {
-        // determine the position and dimensions of the unit
-        const BWAPI::Position& pos = unit->getPosition();
-        int left = pos.x - unit->getType().dimensionLeft();
-        int right = pos.x + unit->getType().dimensionRight();
-        int top = pos.y - unit->getType().dimensionUp();
-        int bottom = pos.y + unit->getType().dimensionDown();
-
-        // if it's a resource, draw the resources remaining
-        if (unit->getType().isResourceContainer() && unit->getInitialResources() > 0) {
-            double mineralRatio = (double)unit->getResources() / (double)unit->getInitialResources();
-            DrawHealthBar(unit, mineralRatio, BWAPI::Colors::Cyan, 0);
-        }
-        // otherwise if it's a unit, draw the hp 
-        else if (unit->getType().maxHitPoints() > 0) {
-            double hpRatio = (double)unit->getHitPoints() / (double)unit->getType().maxHitPoints();
-            BWAPI::Color hpColor = BWAPI::Colors::Green;
-            if (hpRatio < 0.66) hpColor = BWAPI::Colors::Orange;
-            if (hpRatio < 0.33) hpColor = BWAPI::Colors::Red;
-            DrawHealthBar(unit, hpRatio, hpColor, 0);
-
-            // if it has shields, draw those too
-            if (unit->getType().maxShields() > 0) {
-                double shieldRatio = (double)unit->getShields() / (double)unit->getType().maxShields();
-                DrawHealthBar(unit, shieldRatio, BWAPI::Colors::Blue, -3);
-            }
-        }
-    }
-}
-
-void Tools::DrawHealthBar(BWAPI::Unit unit, double ratio, BWAPI::Color color, int yOffset) {
-    int verticalOffset = -10;
-    const BWAPI::Position& pos = unit->getPosition();
-
-    int left = pos.x - unit->getType().dimensionLeft();
-    int right = pos.x + unit->getType().dimensionRight();
-    int top = pos.y - unit->getType().dimensionUp();
-    int bottom = pos.y + unit->getType().dimensionDown();
-
-    int ratioRight = left + (int)((right - left) * ratio);
-    int hpTop = top + yOffset + verticalOffset;
-    int hpBottom = top + 4 + yOffset + verticalOffset;
-
-    BWAPI::Broodwar->drawBoxMap(BWAPI::Position(left, hpTop), BWAPI::Position(right, hpBottom), BWAPI::Colors::Grey, true);
-    BWAPI::Broodwar->drawBoxMap(BWAPI::Position(left, hpTop), BWAPI::Position(ratioRight, hpBottom), color, true);
-    BWAPI::Broodwar->drawBoxMap(BWAPI::Position(left, hpTop), BWAPI::Position(right, hpBottom), BWAPI::Colors::Black, false);
-
-    int ticWidth = 3;
-
-    for (int i(left); i < right - 1; i += ticWidth) {
-        BWAPI::Broodwar->drawLineMap(BWAPI::Position(i, hpTop), BWAPI::Position(i, hpBottom), BWAPI::Colors::Black);
+    switch (event.getType()) {
+    case bw::EventType::MatchStart:
+        onStart();
+        break;
+    case bw::EventType::MatchFrame:
+        onFrame();
+        onDraw();
+        break;
+    case bw::EventType::MatchEnd:
+        onEnd(event.isWinner());
+        break;
+    case bw::EventType::SendText:
+        onSendText(event.getText());
+        break;
+    case bw::EventType::ReceiveText:
+        onReceiveText(event.getPlayer(), event.getText());
+        break;
+    case bw::EventType::UnitCreate:
+        onUnitCreate(event.getUnit());
+        break;
+    case bw::EventType::UnitDestroy:
+        onUnitDestroy(event.getUnit());
+        break;
+    case bw::EventType::UnitComplete:
+        onUnitComplete(event.getUnit());
+        break;
+    case bw::EventType::UnitMorph:
+        onUnitMorph(event.getUnit());
+        break;
+    case bw::EventType::UnitRenegade:
+        onUnitRenegade(event.getUnit());
+        break;
+    case bw::EventType::UnitHide:
+        onUnitHide(event.getUnit());
+        break;
+    case bw::EventType::UnitShow:
+        onUnitShow(event.getUnit());
+        break;
+    case bw::EventType::UnitEvade:
+        onUnitEvade(event.getUnit());
+        break;
+    case bw::EventType::UnitDiscover:
+        onUnitDiscover(event.getUnit());
+        break;
     }
 }

--- a/src/starterbot/Tools.h
+++ b/src/starterbot/Tools.h
@@ -11,21 +11,71 @@ namespace bw {
 extern bw::GameWrapper& g_game;
 extern bw::Player g_self;
 
-namespace Tools {
-    BWAPI::Unit GetClosestUnitTo(BWAPI::Position p, const BWAPI::Unitset& units);
-    BWAPI::Unit GetClosestUnitTo(BWAPI::Unit unit, const BWAPI::Unitset& units);
+extern int g_gameCount;
 
-    int CountUnitsOfType(BWAPI::UnitType type, const BWAPI::Unitset& units);
+// This is the base class for all classes that receive events from BWAPI. It contains
+// virtual methods for each event that is relevant for the bot to respond to, plus a way
+// to dispatch events to subordinate classes that also need to receive events.
+class EventReceiver {
+public:
+    virtual ~EventReceiver() = default;
 
-    BWAPI::Unit GetUnitOfType(BWAPI::UnitType type);
+	// Notifies this event receiver when a new event has been received. This first passes
+	// the event to subordinate classes via notifyMembers(), and then calls the
+	// appropriate virtual event handler on this class.
+    void notifyReceiver(const bw::Event& event);
 
-    bool BuildBuilding(BWAPI::UnitType type);
+protected:
+	// If this event receiver has subordinate classes that need to be notified about new
+	// events, this method can be overridden to call the notifyReceiver() method of each
+	// subordinate class.
+    virtual void notifyMembers(const bw::Event& event) {}
 
-    void DrawUnitBoundingBoxes();
-    void DrawUnitCommands();
+	// Called whenever a game starts with the number of the current game. Classes that
+	// derive from EventReceiver are created once and reused for every match, so
+	// initialization for each game should happen here rather than in the constructor.
+	virtual void onStart() {}
 
-    int GetTotalSupply(bool inProgress = false);
+	// Called for every frame of the game. Much of the main bot logic occurs here.
+	virtual void onFrame() {}
 
-    void DrawUnitHealthBars();
-    void DrawHealthBar(BWAPI::Unit unit, double ratio, BWAPI::Color color, int yOffset);
-}
+	// Like onFrame(), this is called for every frame of the game. However, drawing code
+	// should be placed here rather than in onFrame().
+	virtual void onDraw() {}
+
+	// Called whenever the game ends, plus information about whether the bot won or lost.
+	virtual void onEnd(bool isWinner) {}
+
+	// Called whenever the user sends or receives a chat message. This can be used to
+	// catch control messages to control bot functionality or enable debugging features.
+	virtual void onSendText(const std::string& text) {}
+	virtual void onReceiveText(bw::Player player, const std::string& text) {}
+
+	// Called when a new unit is created. Both Zerg morphing and construction of
+	// structures over a Vespene geyser count as morphing rather than creation.
+	virtual void onUnitCreate(bw::Unit unit) {}
+
+	// Called when a unit is destroyed or removed from the game for some reason.
+	virtual void onUnitDestroy(bw::Unit unit) {}
+
+	// Called when a unit changes from incomplete to complete, such as a building that
+	// finished construction or a unit that completed training.
+	virtual void onUnitComplete(bw::Unit unit) {}
+
+	// Called when a unit changes from one unit type to a different unit type.
+	virtual void onUnitMorph(bw::Unit unit) {}
+
+	// Called when a unit changes ownership, such as from a Protoss mind control ability.
+	virtual void onUnitRenegade(bw::Unit unit) {}
+
+	// Called when a unit becomes visible or invisible, such as by the fog of war or by
+	// using a cloaking ability.
+	virtual void onUnitShow(bw::Unit unit) {}
+	virtual void onUnitHide(bw::Unit unit) {}
+
+	// Called when a unit becomes accessible or inaccessible. This appears to be the same
+	// as onUnitShow() and onUnitHide(), except that they will not be fired when complete
+	// map information is enabled for BWAPI.
+	virtual void onUnitEvade(bw::Unit unit) {}
+	virtual void onUnitDiscover(bw::Unit unit) {}
+};

--- a/src/starterbot/UnitManager.cpp
+++ b/src/starterbot/UnitManager.cpp
@@ -1,0 +1,114 @@
+#include "UnitManager.h"
+
+bw::Unit UnitManager::matchUnit(const bw::Unitset& units, const bw::UnitFilter& pred) {
+    for (bw::Unit unit : units) {
+        if (pred(unit)) {
+            return unit;
+        }
+    }
+
+    return nullptr;
+}
+
+bw::Unitset UnitManager::matchUnits(const bw::Unitset& units, const bw::UnitFilter& pred, int count) {
+    bw::Unitset matches;
+
+    for (bw::Unit unit : units) {
+        if (matches.size() >= count) {
+            break;
+        }
+
+        if (pred(unit)) {
+            matches.insert(unit);
+        }
+    }
+
+    return matches;
+}
+
+int UnitManager::matchCount(const bw::Unitset& units, const bw::UnitFilter& pred) {
+    int count = 0;
+
+    for (bw::Unit unit : units) {
+        if (pred(unit)) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+bw::Unit UnitManager::peekUnit(const bw::UnitFilter& pred, bool progress) {
+    return matchUnit(progress ? g_self->getUnits() : m_allUnits, pred);
+}
+
+bw::Unitset UnitManager::peekUnits(const bw::UnitFilter& pred, int count, bool progress) {
+    return matchUnits(progress ? g_self->getUnits() : m_allUnits, pred, count);
+}
+
+int UnitManager::peekCount(const bw::UnitFilter& pred, bool progress) {
+    return matchCount(progress ? g_self->getUnits() : m_allUnits, pred);
+}
+
+bw::Unit UnitManager::borrowUnit(const bw::UnitFilter& pred) {
+    return matchUnit(m_freeUnits, pred);
+}
+
+bw::Unitset UnitManager::borrowUnits(const bw::UnitFilter& pred, int count) {
+    return matchUnits(m_freeUnits, pred, count);
+}
+
+int UnitManager::borrowCount(const bw::UnitFilter& pred) {
+    return matchCount(m_freeUnits, pred);
+}
+
+bw::Unit UnitManager::reserveUnit(const bw::UnitFilter& pred) {
+    bw::Unit unit = matchUnit(m_freeUnits, pred);
+    m_freeUnits.erase(unit);
+    return unit;
+}
+
+bw::Unitset UnitManager::reserveUnits(const bw::UnitFilter& pred, int count) {
+    bw::Unitset units = matchUnits(m_freeUnits, pred, count);
+    for (bw::Unit unit : units) {
+        m_freeUnits.erase(unit);
+    }
+    return units;
+}
+
+void UnitManager::releaseUnit(bw::Unit& unit, const bw::UnitFilter& pred) {
+    if (!pred.isValid() || pred(unit)) {
+        m_freeUnits.insert(unit);
+        unit = nullptr;
+    }
+}
+
+void UnitManager::releaseUnits(bw::Unitset& units, const bw::UnitFilter& pred) {
+    auto it = units.begin();
+
+    while (it != units.end()) {
+        bw::Unit unit = *it;
+
+        if (!pred.isValid() || pred(unit)) {
+            m_freeUnits.insert(unit);
+            it = units.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void UnitManager::onStart() {
+    m_allUnits.clear();
+    m_freeUnits.clear();
+}
+
+void UnitManager::onUnitComplete(bw::Unit unit) {
+    m_allUnits.insert(unit);
+    m_freeUnits.insert(unit);
+}
+
+void UnitManager::onUnitDestroy(bw::Unit unit) {
+    m_allUnits.erase(unit);
+    m_freeUnits.erase(unit);
+}

--- a/src/starterbot/UnitManager.h
+++ b/src/starterbot/UnitManager.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Tools.h"
+
+#include <climits>
+
+class UnitManager : public EventReceiver {
+private:
+    bw::Unitset m_allUnits;
+    bw::Unitset m_freeUnits;
+
+public:
+    static bw::Unit matchUnit(const bw::Unitset& units, const bw::UnitFilter& pred = nullptr);
+    static bw::Unitset matchUnits(const bw::Unitset& units,
+        const bw::UnitFilter& pred = nullptr, int count = INT_MAX);
+    static int matchCount(const bw::Unitset& units, const bw::UnitFilter& pred = nullptr);
+
+    bw::Unit peekUnit(const bw::UnitFilter& pred, bool progress = false);
+    bw::Unitset peekUnits(const bw::UnitFilter& pred, int count = INT_MAX, bool progress = false);
+    int peekCount(const bw::UnitFilter& pred, bool progress = false);
+
+    bw::Unit borrowUnit(const bw::UnitFilter& pred);
+    bw::Unitset borrowUnits(const bw::UnitFilter& pred, int count = INT_MAX);
+    int borrowCount(const bw::UnitFilter& pred);
+
+    bw::Unit reserveUnit(const bw::UnitFilter& pred);
+    bw::Unitset reserveUnits(const bw::UnitFilter& pred, int count = INT_MAX);
+
+    void releaseUnit(bw::Unit& unit, const bw::UnitFilter& pred = nullptr);
+    void releaseUnits(bw::Unitset& units, const bw::UnitFilter& pred = nullptr);
+
+protected:
+    virtual void onStart() override;
+    virtual void onUnitComplete(bw::Unit unit) override;
+    virtual void onUnitDestroy(bw::Unit unit) override;
+};

--- a/visualstudio/StarterBot.vcxproj
+++ b/visualstudio/StarterBot.vcxproj
@@ -20,12 +20,16 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
+    <ClInclude Include="..\src\starterbot\StrategyManager.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
+    <ClInclude Include="..\src\starterbot\UnitManager.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\starterbot\main.cpp" />
     <ClCompile Include="..\src\starterbot\AutoPilotBot.cpp" />
+    <ClCompile Include="..\src\starterbot\StrategyManager.cpp" />
     <ClCompile Include="..\src\starterbot\Tools.cpp" />
+    <ClCompile Include="..\src\starterbot\UnitManager.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>StarterBot</ProjectName>

--- a/visualstudio/StarterBot.vcxproj
+++ b/visualstudio/StarterBot.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
     <ClInclude Include="..\src\starterbot\StrategyManager.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
+    <ClInclude Include="..\src\starterbot\BuildingManager.h" />
     <ClInclude Include="..\src\starterbot\UnitManager.h" />
   </ItemGroup>
   <ItemGroup>
@@ -29,6 +30,7 @@
     <ClCompile Include="..\src\starterbot\AutoPilotBot.cpp" />
     <ClCompile Include="..\src\starterbot\StrategyManager.cpp" />
     <ClCompile Include="..\src\starterbot\Tools.cpp" />
+    <ClCompile Include="..\src\starterbot\BuildingManager.cpp" />
     <ClCompile Include="..\src\starterbot\UnitManager.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/visualstudio/StarterBot.vcxproj.filters
+++ b/visualstudio/StarterBot.vcxproj.filters
@@ -4,9 +4,13 @@
     <ClCompile Include="..\src\starterbot\main.cpp" />
     <ClCompile Include="..\src\starterbot\AutoPilotBot.cpp" />
     <ClCompile Include="..\src\starterbot\Tools.cpp" />
+    <ClCompile Include="..\src\starterbot\StrategyManager.cpp" />
+    <ClCompile Include="..\src\starterbot\UnitManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
+    <ClInclude Include="..\src\starterbot\StrategyManager.h" />
+    <ClInclude Include="..\src\starterbot\UnitManager.h" />
   </ItemGroup>
 </Project>

--- a/visualstudio/StarterBot.vcxproj.filters
+++ b/visualstudio/StarterBot.vcxproj.filters
@@ -6,11 +6,13 @@
     <ClCompile Include="..\src\starterbot\Tools.cpp" />
     <ClCompile Include="..\src\starterbot\StrategyManager.cpp" />
     <ClCompile Include="..\src\starterbot\UnitManager.cpp" />
+    <ClCompile Include="..\src\starterbot\BuildingManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
     <ClInclude Include="..\src\starterbot\StrategyManager.h" />
     <ClInclude Include="..\src\starterbot\UnitManager.h" />
+    <ClInclude Include="..\src\starterbot\BuildingManager.h" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Creates `StrategyManager` and `UnitManager`. Also implements the `EventReceiver` class and makes the manager classes inherit from it.  The drawing functions in `Tools.h` functions have been merged into the `AutoPilotBot` class. `StrategyManager` is largely unimplemented at the moment until the `ProductionManager` and `BuildingManager` classes have been implemented.

Note that the workers will no longer collect resources or build pylons. That code has been removed for this PR, since it needs to be moved to the `ProductionManager` class.