### PR TITLE
Implement IntelManager and ScoutManager; make StrategyManager more intelligent

### DIFF
--- a/src/starterbot/IntelManager.cpp
+++ b/src/starterbot/IntelManager.cpp
@@ -1,0 +1,81 @@
+#include "IntelManager.h"
+
+#include "UnitManager.h"
+
+bool IntelManager::isEnemy(bw::Unit unit) {
+    return g_game->enemies().count(unit->getPlayer());
+}
+
+bw::TilePosition IntelManager::getLastPosition(bw::Unit unit) {
+    if (m_lastPositions.count(unit)) {
+        return m_lastPositions[unit];
+    }
+    return bw::TilePositions::Unknown;
+}
+
+bw::Unit IntelManager::peekUnit(const bw::UnitFilter& pred) {
+    return UnitManager::matchUnit(m_enemyUnits, pred);
+}
+
+bw::Unitset IntelManager::peekUnits(const bw::UnitFilter& pred, int count) {
+    return UnitManager::matchUnits(m_enemyUnits, pred, count);
+}
+
+int IntelManager::peekCount(const bw::UnitFilter& pred) {
+    return UnitManager::matchCount(m_enemyUnits, pred);
+}
+
+bw::Unit IntelManager::findUnit(const bw::UnitFilter& pred) {
+    return UnitManager::matchUnit(m_visibleUnits, pred);
+}
+
+bw::Unitset IntelManager::findUnits(const bw::UnitFilter& pred, int count) {
+    return UnitManager::matchUnits(m_visibleUnits, pred, count);
+}
+
+int IntelManager::findCount(const bw::UnitFilter& pred) {
+    return UnitManager::matchCount(m_visibleUnits, pred);
+}
+
+void IntelManager::onStart() {
+    m_enemyUnits.clear();
+    m_visibleUnits.clear();
+
+    m_lastPositions.clear();
+}
+
+void IntelManager::onFrame() {
+    for (bw::Unit unit : g_game->getAllUnits()) {
+        if (isEnemy(unit)) {
+            m_enemyUnits.insert(unit);
+            m_visibleUnits.insert(unit);
+
+            m_lastPositions[unit] = unit->getTilePosition();
+        }
+    }
+
+    auto it = m_lastPositions.begin();
+
+    while (it != m_lastPositions.end()) {
+        if (!it->first->isVisible() && g_game->isVisible(it->second)) {
+            it = m_lastPositions.erase(it);
+        } else {
+            it++;
+        }
+    }
+}
+
+void IntelManager::onUnitHide(bw::Unit unit) {
+    if (isEnemy(unit)) {
+        m_visibleUnits.erase(unit);
+    }
+}
+
+void IntelManager::onUnitDestroy(bw::Unit unit) {
+    if (isEnemy(unit)) {
+        m_enemyUnits.erase(unit);
+        m_visibleUnits.erase(unit);
+
+        m_lastPositions.erase(unit);
+    }
+}

--- a/src/starterbot/IntelManager.h
+++ b/src/starterbot/IntelManager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Tools.h"
+
+#include <unordered_map>
+
+class IntelManager : public EventReceiver {
+private:
+    bw::Unitset m_enemyUnits;
+    bw::Unitset m_visibleUnits;
+
+    std::unordered_map<bw::Unit, bw::TilePosition> m_lastPositions;
+
+public:
+    static bool isEnemy(bw::Unit unit);
+
+    bw::TilePosition getLastPosition(bw::Unit unit);
+
+    bw::Unit peekUnit(const bw::UnitFilter& pred);
+    bw::Unitset peekUnits(const bw::UnitFilter& pred, int count = INT_MAX);
+    int peekCount(const bw::UnitFilter& pred);
+
+    bw::Unit findUnit(const bw::UnitFilter& pred);
+    bw::Unitset findUnits(const bw::UnitFilter& pred, int count = INT_MAX);
+    int findCount(const bw::UnitFilter& pred);
+
+protected:
+    virtual void onStart() override;
+    virtual void onFrame() override;
+    virtual void onUnitHide(bw::Unit unit) override;
+    virtual void onUnitDestroy(bw::Unit unit) override;
+};

--- a/src/starterbot/ProductionManager.cpp
+++ b/src/starterbot/ProductionManager.cpp
@@ -5,7 +5,11 @@ ProductionManager::ProductionManager(UnitManager& unitManager) :
 }
 
 bool ProductionManager::addBuildRequest(bw::UnitType type) {
-    bw::TilePosition pos = g_game->getBuildLocation(type, g_self->getStartLocation(), 64, false);
+    if (type.mineralPrice() > g_self->minerals()) {
+        return false;
+    }
+
+    bw::TilePosition pos = g_game->getBuildLocation(type, g_self->getStartLocation(), 32, false);
     if (pos == bw::TilePositions::Invalid) {
         return false;
     }

--- a/src/starterbot/ScoutManager.cpp
+++ b/src/starterbot/ScoutManager.cpp
@@ -1,0 +1,41 @@
+#include "ScoutManager.h"
+
+ScoutManager::ScoutManager(UnitManager& unitManager) :
+    m_unitManager(unitManager) {
+}
+
+bool ScoutManager::addScout(bw::UnitType type) {
+    bw::Unit scout = m_unitManager.reserveUnit(bw::Filter::GetType == type);
+    if (scout == nullptr) {
+        return false;
+    }
+
+    m_scouts.insert(scout);
+    return true;
+}
+
+int ScoutManager::countScouts(bw::UnitType type) {
+    return UnitManager::matchCount(m_scouts, bw::Filter::GetType == type);
+}
+
+void ScoutManager::onStart() {
+    m_scouts.clear();
+}
+
+void ScoutManager::onFrame() {
+    for (bw::Unit scout : m_scouts) {
+        if (scout->isMoving()) {
+            continue;
+        }
+
+        for (bw::TilePosition pos : g_game->getStartLocations()) {
+            if (!g_game->isExplored(pos)) {
+                scout->move(bw::Position(pos));
+            }
+        }
+    }
+}
+
+void ScoutManager::onUnitDestroy(bw::Unit unit) {
+    m_scouts.erase(unit);
+}

--- a/src/starterbot/ScoutManager.h
+++ b/src/starterbot/ScoutManager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "IntelManager.h"
+#include "Tools.h"
+#include "UnitManager.h"
+
+class ScoutManager : public EventReceiver {
+private:
+    UnitManager& m_unitManager;
+
+    bw::Unitset m_scouts;
+
+public:
+    ScoutManager(UnitManager& unitManager);
+
+    bool addScout(bw::UnitType type);
+    int countScouts(bw::UnitType type);
+
+protected:
+    virtual void onStart() override;
+    virtual void onFrame() override;
+    virtual void onUnitDestroy(bw::Unit unit) override;
+};

--- a/src/starterbot/StrategyManager.cpp
+++ b/src/starterbot/StrategyManager.cpp
@@ -7,6 +7,8 @@ StrategyManager::StrategyManager() :
 
 void StrategyManager::notifyMembers(const bw::Event& event) {
     m_unitManager.notifyReceiver(event);
+    m_intelManager.notifyReceiver(event);
+
     m_productionManager.notifyReceiver(event);
     m_buildingManager.notifyReceiver(event);
 }

--- a/src/starterbot/StrategyManager.cpp
+++ b/src/starterbot/StrategyManager.cpp
@@ -2,7 +2,8 @@
 
 StrategyManager::StrategyManager() :
     m_productionManager(m_unitManager),
-    m_buildingManager(m_unitManager) {
+    m_buildingManager(m_unitManager),
+    m_scoutManager(m_unitManager) {
 }
 
 void StrategyManager::notifyMembers(const bw::Event& event) {
@@ -11,65 +12,77 @@ void StrategyManager::notifyMembers(const bw::Event& event) {
 
     m_productionManager.notifyReceiver(event);
     m_buildingManager.notifyReceiver(event);
+    m_scoutManager.notifyReceiver(event);
 }
 
 void StrategyManager::onStart() {
     m_strategy = {
-        {ActionType::TRAIN, bw::UnitTypes::Protoss_Probe, 8},
-        {ActionType::BUILD, bw::UnitTypes::Protoss_Pylon, 1},
-        {ActionType::TRAIN, bw::UnitTypes::Protoss_Probe, 15},
-        {ActionType::BUILD, bw::UnitTypes::Protoss_Gateway, 1},
-        {ActionType::TRAIN, bw::UnitTypes::Protoss_Zealot, 5},
+        {ActionType::TRAIN,  ActionItem::NONE, bw::UnitTypes::Protoss_Probe,        8 }, // 0
+        {ActionType::BUILD,  0,                bw::UnitTypes::Protoss_Pylon,        1 }, // 1
+        {ActionType::TRAIN,  1,                bw::UnitTypes::Protoss_Probe,        9 }, // 2
+        {ActionType::BUILD,  2,                bw::UnitTypes::Protoss_Gateway,      1 }, // 3
+        {ActionType::BUILD,  3,                bw::UnitTypes::Protoss_Gateway,      2 }, // 4
+        {ActionType::SCOUT,  4,                bw::UnitTypes::Protoss_Probe,        1 }, // 5
+        {ActionType::TRAIN,  3,                bw::UnitTypes::Protoss_Zealot,       4 }, // 6
+        {ActionType::BUILD,  5,                bw::UnitTypes::Protoss_Pylon,        2 }, // 7
+        {ActionType::TRAIN,  5,                bw::UnitTypes::Protoss_Probe,        16}, // 0
+        {ActionType::ATTACK, 6,                                                       }, // 9
     };
-    m_strategyItem = 0;
+
+    m_completion.clear();
+    m_completion.resize(m_strategy.size());
 }
 
 void StrategyManager::onFrame() {
-    if (m_strategyItem >= m_strategy.size()) {
-        return;
-    }
+    for (int i = 0; i < m_strategy.size(); i++) {
+        const ActionItem& item = m_strategy[i];
 
-    const ActionItem& item = m_strategy[m_strategyItem];
-
-    switch (item.type) {
-    case ActionType::BUILD:
-    {
-        int current = m_unitManager.peekCount(bw::Filter::GetType == item.unit, false);
-        int progress = m_unitManager.peekCount(bw::Filter::GetType == item.unit, true) +
-            m_productionManager.countBuildRequests(item.unit);
-
-        if (current >= item.count) {
-            m_strategyItem++;
+        if (item.depends != ActionItem::NONE && !m_completion[item.depends]) {
+            continue;
         }
 
-        while (progress < item.count && m_productionManager.addBuildRequest(item.unit)) {
-            progress++;
+        switch (item.action) {
+        case ActionType::BUILD:
+        {
+            int current = m_unitManager.peekCount(bw::Filter::GetType == item.type, true);
+            int progress = current + m_productionManager.countBuildRequests(item.type);
+
+            m_completion[i] = current >= item.count;
+
+            while (progress < item.count && m_productionManager.addBuildRequest(item.type)) {
+                progress++;
+            }
+            break;
         }
 
-        break;
-    }
+        case ActionType::TRAIN:
+        {
+            int current = m_unitManager.peekCount(bw::Filter::GetType == item.type, false);
+            int progress = m_unitManager.peekCount(bw::Filter::GetType == item.type, true);
 
-    case ActionType::TRAIN:
-    {
-        int current = m_unitManager.peekCount(bw::Filter::GetType == item.unit, false);
-        int progress = m_unitManager.peekCount(bw::Filter::GetType == item.unit, true);
+            m_completion[i] = current >= item.count;
 
-        if (current >= item.count) {
-            m_strategyItem++;
+            while (progress < item.count && m_buildingManager.addTrainRequest(item.type)) {
+                progress++;
+            }
+            break;
         }
 
-        while (progress < item.count && m_buildingManager.addTrainRequest(item.unit)) {
-            progress++;
+        case ActionType::SCOUT:
+        {
+            int current = m_scoutManager.countScouts(item.type);
+
+            m_completion[i] = current >= item.count;
+
+            while (current < item.count && m_scoutManager.addScout(item.type)) {
+                current++;
+            }
+            break;
         }
-        break;
-    }
 
-    case ActionType::SCOUT:
-        // TODO
-        break;
-
-    case ActionType::ATTACK:
-        // TODO
-        break;
+        case ActionType::ATTACK:
+            // TODO
+            break;
+        }
     }
 }

--- a/src/starterbot/StrategyManager.h
+++ b/src/starterbot/StrategyManager.h
@@ -3,6 +3,7 @@
 #include "BuildingManager.h"
 #include "IntelManager.h"
 #include "ProductionManager.h"
+#include "ScoutManager.h"
 #include "Tools.h"
 #include "UnitManager.h"
 
@@ -16,9 +17,13 @@ enum class ActionType {
 };
 
 struct ActionItem {
-    ActionType type;
-    bw::UnitType unit;
-    int count;
+    static constexpr int NONE = -1;
+
+    ActionType action;
+    int depends;
+
+    bw::UnitType type = bw::UnitTypes::None;
+    int count = 0;
 };
 
 class StrategyManager : public EventReceiver {
@@ -28,9 +33,10 @@ private:
 
     ProductionManager m_productionManager;
     BuildingManager m_buildingManager;
+    ScoutManager m_scoutManager;
 
     std::vector<ActionItem> m_strategy;
-    int m_strategyItem;
+    std::vector<bool> m_completion;
 
 public:
     StrategyManager();

--- a/src/starterbot/StrategyManager.h
+++ b/src/starterbot/StrategyManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BuildingManager.h"
+#include "IntelManager.h"
 #include "ProductionManager.h"
 #include "Tools.h"
 #include "UnitManager.h"
@@ -23,6 +24,7 @@ struct ActionItem {
 class StrategyManager : public EventReceiver {
 private:
     UnitManager m_unitManager;
+    IntelManager m_intelManager;
 
     ProductionManager m_productionManager;
     BuildingManager m_buildingManager;

--- a/visualstudio/StarterBot.vcxproj
+++ b/visualstudio/StarterBot.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
     <ClInclude Include="..\src\starterbot\ProductionManager.h" />
     <ClInclude Include="..\src\starterbot\IntelManager.h" />
+    <ClInclude Include="..\src\starterbot\ScoutManager.h" />
     <ClInclude Include="..\src\starterbot\StrategyManager.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
     <ClInclude Include="..\src\starterbot\BuildingManager.h" />
@@ -32,6 +33,7 @@
     <ClCompile Include="..\src\starterbot\main.cpp" />
     <ClCompile Include="..\src\starterbot\AutoPilotBot.cpp" />
     <ClCompile Include="..\src\starterbot\ProductionManager.cpp" />
+    <ClCompile Include="..\src\starterbot\ScoutManager.cpp" />
     <ClCompile Include="..\src\starterbot\StrategyManager.cpp" />
     <ClCompile Include="..\src\starterbot\Tools.cpp" />
     <ClCompile Include="..\src\starterbot\BuildingManager.cpp" />

--- a/visualstudio/StarterBot.vcxproj
+++ b/visualstudio/StarterBot.vcxproj
@@ -21,12 +21,14 @@
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
     <ClInclude Include="..\src\starterbot\ProductionManager.h" />
+    <ClInclude Include="..\src\starterbot\IntelManager.h" />
     <ClInclude Include="..\src\starterbot\StrategyManager.h" />
     <ClInclude Include="..\src\starterbot\Tools.h" />
     <ClInclude Include="..\src\starterbot\BuildingManager.h" />
     <ClInclude Include="..\src\starterbot\UnitManager.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\starterbot\IntelManager.cpp" />
     <ClCompile Include="..\src\starterbot\main.cpp" />
     <ClCompile Include="..\src\starterbot\AutoPilotBot.cpp" />
     <ClCompile Include="..\src\starterbot\ProductionManager.cpp" />

--- a/visualstudio/StarterBot.vcxproj.filters
+++ b/visualstudio/StarterBot.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="..\src\starterbot\UnitManager.cpp" />
     <ClCompile Include="..\src\starterbot\BuildingManager.cpp" />
     <ClCompile Include="..\src\starterbot\ProductionManager.cpp" />
+    <ClCompile Include="..\src\starterbot\IntelManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
@@ -16,5 +17,6 @@
     <ClInclude Include="..\src\starterbot\UnitManager.h" />
     <ClInclude Include="..\src\starterbot\BuildingManager.h" />
     <ClInclude Include="..\src\starterbot\ProductionManager.h" />
+    <ClInclude Include="..\src\starterbot\IntelManager.h" />
   </ItemGroup>
 </Project>

--- a/visualstudio/StarterBot.vcxproj.filters
+++ b/visualstudio/StarterBot.vcxproj.filters
@@ -9,6 +9,7 @@
     <ClCompile Include="..\src\starterbot\BuildingManager.cpp" />
     <ClCompile Include="..\src\starterbot\ProductionManager.cpp" />
     <ClCompile Include="..\src\starterbot\IntelManager.cpp" />
+    <ClCompile Include="..\src\starterbot\ScoutManager.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\starterbot\AutoPilotBot.h" />
@@ -18,5 +19,6 @@
     <ClInclude Include="..\src\starterbot\BuildingManager.h" />
     <ClInclude Include="..\src\starterbot\ProductionManager.h" />
     <ClInclude Include="..\src\starterbot\IntelManager.h" />
+    <ClInclude Include="..\src\starterbot\ScoutManager.h" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add `IntelManager`. Currently, this is unused by `ScoutManager` but will be used in the future. It's also necessary for `CombatManager`.
* Add `ScoutManager`. Scouts are currently as stupid as they come--they just explore every possible starting location and then stop. This is sufficient to find the enemy base, but that's it.
* Make `StrategyManager` more intelligent by allowing `ActionItem`s to be processed in parallel. There's a `depends` field on each `ActionItem` that says which `ActionItem` is a prerequisite for this one, e.g. building a gateway is listed as a prerequisite to training zealots. Otherwise, they work in parallel. The current strategy is [9/9 Gateways](https://liquipedia.net/starcraft/2_Gateway_(vs._Zerg)).